### PR TITLE
fix: correct language after page reloading

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -32,10 +32,10 @@ app.get('/', async (req: Request, res: Response) => {
 
   const langToServe = cookieLang && allowed.has(cookieLang) ? cookieLang : defaultLang;
 
-  const nextLang = cookieLang && langToServe === 'uk' ? 'en' : 'uk';
-  res.cookie('lang', nextLang, { maxAge: 90_0000, httpOnly: true });
-
-  const t = translations[nextLang];
+  if (!cookieLang) {
+    res.cookie('lang', langToServe, { maxAge: 90_0000, httpOnly: true });
+  }
+  const t = translations[langToServe];
   const contacts = await fetchContacts();
 
   if (!contacts) {
@@ -51,8 +51,17 @@ app.get('/', async (req: Request, res: Response) => {
     header: t.header,
     body: t.body,
     contacts: merger,
-    lang: nextLang
+    lang: langToServe
   });
+});
+
+app.get('/set-lang/:lang', (req: Request, res: Response) => {
+  const { lang } = req.params;
+
+  if (allowed.has(lang)) {
+    res.cookie('lang', lang, { maxAge: 90_0000, httpOnly: true });
+    return res.sendStatus(200);
+  }
 });
 
 app.listen(PORT, () => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -30,11 +30,18 @@ const allowed = new Set(['en', 'uk']);
 app.get('/', async (req: Request, res: Response) => {
   const cookieLang = typeof req.cookies?.lang === 'string' ? req.cookies.lang : undefined;
 
-  const langToServe = cookieLang && allowed.has(cookieLang) ? cookieLang : defaultLang;
+  let langToServe = cookieLang && allowed.has(cookieLang) ? cookieLang : defaultLang;
 
-  if (!cookieLang) {
+  const isFetch = req.headers['sec-fetch-dest'] === 'empty';
+
+  if (isFetch) {
+    langToServe = langToServe === 'uk' ? 'en' : 'uk';
+  }
+
+  if (isFetch || !cookieLang) {
     res.cookie('lang', langToServe, { maxAge: 90_0000, httpOnly: true });
   }
+
   const t = translations[langToServe];
   const contacts = await fetchContacts();
 
@@ -53,15 +60,6 @@ app.get('/', async (req: Request, res: Response) => {
     contacts: merger,
     lang: langToServe
   });
-});
-
-app.get('/set-lang/:lang', (req: Request, res: Response) => {
-  const { lang } = req.params;
-
-  if (allowed.has(lang)) {
-    res.cookie('lang', lang, { maxAge: 90_0000, httpOnly: true });
-    return res.sendStatus(200);
-  }
 });
 
 app.listen(PORT, () => {

--- a/static/scripts/script.js
+++ b/static/scripts/script.js
@@ -1,5 +1,10 @@
 async function switchLanguage() {
   try {
+    const currentLang = document.documentElement.lang || 'uk';
+    const nextLang = currentLang === 'uk' ? 'en' : 'uk';
+
+    await fetch(`/set-lang/${nextLang}`);
+
     const res = await fetch('/', { credentials: 'same-origin' });
     const html = await res.text();
 
@@ -11,7 +16,7 @@ async function switchLanguage() {
     const oldApp = document.getElementById('App');
     oldApp.replaceWith(newApp.cloneNode(true));
 
-    document.documentElement.lang = doc.documentElement.lang;
+    document.documentElement.lang = nextLang;
   } catch (err) {
     window.location.href = '/';
   }

--- a/static/scripts/script.js
+++ b/static/scripts/script.js
@@ -1,10 +1,5 @@
 async function switchLanguage() {
   try {
-    const currentLang = document.documentElement.lang || 'uk';
-    const nextLang = currentLang === 'uk' ? 'en' : 'uk';
-
-    await fetch(`/set-lang/${nextLang}`);
-
     const res = await fetch('/', { credentials: 'same-origin' });
     const html = await res.text();
 
@@ -16,7 +11,7 @@ async function switchLanguage() {
     const oldApp = document.getElementById('App');
     oldApp.replaceWith(newApp.cloneNode(true));
 
-    document.documentElement.lang = nextLang;
+    document.documentElement.lang = doc.documentElement.lang;
   } catch (err) {
     window.location.href = '/';
   }


### PR DESCRIPTION
## Description

<!-- Briefly describe the purpose of this PR and what was changed -->
Changed the language logic from switching the language on every reload to persisting between reloads. Now, the language only switches when the user explicitly clicks the switch button.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Open the site (should be Ukrainian by default).
2. Refresh the page - the language should not change.
3. Click the language switch button - the content should swap to English instantly.
4. Click a "copy" button - the tooltip should match the active language.

## Video / Screenshots

<!-- Attach a video recording or screenshots demonstrating the changes, if applicable -->

https://github.com/user-attachments/assets/ef10c278-e6a9-4553-86b7-8b31e4954cfc


## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
